### PR TITLE
CI fixes for public CI, update outdated dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
                     git \
                     curl \
                     build-essential \
-                    cmake
+                    cmake \
+                    git-lfs
             - uses: actions/checkout@v3
               with:
                 lfs: true
@@ -127,7 +128,8 @@ jobs:
                     git \
                     curl \
                     build-essential \
-                    cmake
+                    cmake \
+                    git-lfs
             - uses: actions/checkout@v3
               with:
                 lfs: true
@@ -179,7 +181,8 @@ jobs:
                     git \
                     curl \
                     build-essential \
-                    cmake
+                    cmake \
+                    git-lfs
             - uses: actions/checkout@v3
               with:
                 lfs: true
@@ -341,7 +344,17 @@ jobs:
             - name: Install Dependencies
               run: |
                   apt-get -y update && \
-                  apt-get -y install git curl jq wget build-essential cmake openssl libssl-dev pkg-config
+                  apt-get -y install \
+                    git \
+                    curl \
+                    jq \
+                    wget \
+                    build-essential \
+                    cmake \
+                    openssl \
+                    libssl-dev \
+                    pkg-config \
+                    git-lfs
             - uses: actions/checkout@v3
               with:
                 lfs: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,6 @@
         "*.in": "cpp"
     },
     "mesonbuild.configureOnOpen": false,
-    // Set the feature to the latest public SIMICS version
     "rust-analyzer.cargo.features": ["6.0.169"],
     "git.ignoreLimitWarning": true
 }

--- a/simics-link/Cargo.toml
+++ b/simics-link/Cargo.toml
@@ -19,7 +19,7 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-cargo_metadata = "0.17.0"
+cargo_metadata = "0.18.0"
 clap = { version = "4.3.0", features = ["derive"] }
 derive_builder = "0.12.0"
 dotenvy_macro = "0.15.7"

--- a/simics/Cargo.toml
+++ b/simics/Cargo.toml
@@ -19,7 +19,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 artifact-dependency.workspace = true
-cargo_metadata = "0.17.0"
+cargo_metadata = "0.18.0"
 clap = { version = "4.3.0", features = ["derive"] }
 derive_builder = "0.12.0"
 dotenvy_macro = "0.15.7"

--- a/util/artifact-dependency/Cargo.toml
+++ b/util/artifact-dependency/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["lib"]
 
 [dependencies]
 anyhow.workspace = true
-cargo_metadata = "0.17.0"
+cargo_metadata = "0.18.0"
 derive_builder = "0.12.0"
 serde = { workspace = true, features = ["derive"] }
 tracing = "0.1.37"


### PR DESCRIPTION
actions/checkout@v3 needs git-lfs to be installed on the system, this wasn't caught locally because `act` replaces the entire `checkout` step.