### PR TITLE
Do not document dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,12 @@ jobs:
                   echo "✅ [T595] Symlinks are checked before using files. See T297."
             - name: Build Docs
               run: |
-                  cargo doc --features=${{ matrix.simics_version }}
+                  cargo doc --features=${{ matrix.simics_version }} --workspace \
+                    --no-deps
             - name: Test Docs
               run: |
-                  cargo test --doc --features=${{ matrix.simics_version }}
+                  cargo test --doc --features=${{ matrix.simics_version }} --workspace \
+                    --no-deps
 
     static_analysis:
         name: Run Static Analysis


### PR DESCRIPTION
Adding `--no-deps` fixes a [doc build error](https://github.com/intel/tsffs/actions/runs/6224604494/job/16893174543) that is out of our control and comes from a dependency.