### PR TITLE
Fix Box::into_raw and add checks

### DIFF
--- a/simics-api/src/safe/base/conf_object.rs
+++ b/simics-api/src/safe/base/conf_object.rs
@@ -68,6 +68,12 @@ where
     // Note: This allocates and never frees. This is *required* by SIMICS and it is an error to
     // free this pointer
     let iface_raw = Box::into_raw(iface_box);
+
+    debug_assert!(
+        std::mem::size_of_val(&iface_raw) == std::mem::size_of::<*mut std::ffi::c_void>(),
+        "Pointer is not convertible to *mut c_void"
+    );
+
     let status = unsafe { SIM_register_interface(cls.into(), name_raw, iface_raw as *mut _) };
 
     if status != 0 {

--- a/simics-api/src/safe/simulator/callbacks.rs
+++ b/simics-api/src/safe/simulator/callbacks.rs
@@ -7,17 +7,29 @@ use simics_api_sys::SIM_run_alone;
 
 extern "C" fn run_alone_handler<F>(cb: *mut c_void)
 where
-    F: FnMut(),
+    F: FnOnce() + 'static,
 {
-    let mut closure: Box<F> = unsafe { Box::from_raw(cb as *mut F) };
+    let closure: Box<Box<F>> = unsafe { Box::from_raw(cb as *mut Box<F>) };
     closure()
 }
 
 pub fn run_alone<F>(cb: F)
 where
-    F: FnMut(),
+    F: FnOnce() + 'static,
 {
     let cb = Box::new(cb);
-    let cb = Box::into_raw(cb);
-    unsafe { SIM_run_alone(Some(run_alone_handler::<F>), cb as *mut _ as *mut c_void) }
+    let cb_box = Box::new(cb);
+    let cb_raw = Box::into_raw(cb_box);
+
+    debug_assert!(
+        std::mem::size_of_val(&cb_raw) == std::mem::size_of::<*mut std::ffi::c_void>(),
+        "Pointer is not convertible to *mut c_void"
+    );
+
+    unsafe {
+        SIM_run_alone(
+            Some(run_alone_handler::<F>),
+            cb_raw as *mut _ as *mut c_void,
+        )
+    }
 }

--- a/simics-fuzz/src/fuzzer/mod.rs
+++ b/simics-fuzz/src/fuzzer/mod.rs
@@ -309,12 +309,22 @@ impl SimicsFuzzer {
 
             let tx = Box::new(make_attr_data_adopt(tx)?);
             let rx = Box::new(make_attr_data_adopt(rx)?);
-            let tx = Box::into_raw(tx);
-            let rx = Box::into_raw(rx);
+            let tx_raw = Box::into_raw(tx);
+            let rx_raw = Box::into_raw(rx);
+
+            debug_assert!(
+                std::mem::size_of_val(&tx_raw) == std::mem::size_of::<*mut std::ffi::c_void>(),
+                "Pointer is not convertible to *mut c_void"
+            );
+
+            debug_assert!(
+                std::mem::size_of_val(&rx_raw) == std::mem::size_of::<*mut std::ffi::c_void>(),
+                "Pointer is not convertible to *mut c_void"
+            );
 
             info!("Setting up channels");
 
-            (unsafe { *tsffs_interface }.add_channels)(tsffs, tx, rx);
+            (unsafe { *tsffs_interface }.add_channels)(tsffs, tx_raw, rx_raw);
 
             info!("Set channel for object");
 


### PR DESCRIPTION
Add debug assertions to ensure Box::into_raw only gives us convertible-to-cffi pointers, and fix discarded vtable as mentioned in #23.