### PR TITLE
Fix libafl build errors

### DIFF
--- a/modules/tsffs/src/tsffs/src/fuzzer/mod.rs
+++ b/modules/tsffs/src/tsffs/src/fuzzer/mod.rs
@@ -164,9 +164,9 @@ impl Tsffs {
                 OwnedMutSlice::from(coverage_map),
             ));
             let aflpp_cmp_observer =
-                AFLppCmpLogObserver::new(Self::AFLPP_CMP_OBSERVER_NAME, aflpp_cmp_map, true);
+                AFLppCmpLogObserver::new(Self::AFLPP_CMP_OBSERVER_NAME, libafl_bolts::ownedref::OwnedRefMut::Ref(aflpp_cmp_map), true);
             let cmplog_observer =
-                StdCmpValuesObserver::new(Self::CMPLOG_OBSERVER_NAME, aflpp_cmp_map_dup, true);
+                StdCmpValuesObserver::new(Self::CMPLOG_OBSERVER_NAME, libafl_bolts::ownedref::OwnedRefMut::Ref(aflpp_cmp_map_dup), true);
             let time_observer = TimeObserver::new(Self::TIME_OBSERVER_NAME);
 
             let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, true);


### PR DESCRIPTION
Ran into the following build errors on a fresh checkout on Ubuntu:

   Compiling tsffs v0.2.1 (/home/drt/workspace/simics/tsffs/modules/tsffs/src/tsffs)
error[E0308]: mismatched types
   --> modules/tsffs/src/tsffs/src/fuzzer/mod.rs:167:73
    |
167 |                 AFLppCmpLogObserver::new(Self::AFLPP_CMP_OBSERVER_NAME, aflpp_cmp_map, true);
    |                 ------------------------                                ^^^^^^^^^^^^^ expected `OwnedRefMut<'_, AFLppCmpLogMap>`, found `&mut AFLppCmpLogMap`
    |                 |
    |                 arguments to this function are incorrect
    |
    = note:           expected enum `OwnedRefMut<'_, AFLppCmpLogMap, >`
            found mutable reference `&mut AFLppCmpLogMap`
note: associated function defined here
   --> /home/drt/.cargo/git/checkouts/libafl-c33dc6f5ec2f7a70/d143cac/libafl_targets/src/cmps/observers/aflpp.rs:182:12
    |
182 |     pub fn new(
    |            ^^^
help: try wrapping the expression in `libafl_bolts::ownedref::OwnedRefMut::Ref`
    |
167 |                 AFLppCmpLogObserver::new(Self::AFLPP_CMP_OBSERVER_NAME, libafl_bolts::ownedref::OwnedRefMut::Ref(aflpp_cmp_map), true);
    |                                                                         +++++++++++++++++++++++++++++++++++++++++             +

error[E0308]: mismatched types
   --> modules/tsffs/src/tsffs/src/fuzzer/mod.rs:169:71
    |
169 |                 StdCmpValuesObserver::new(Self::CMPLOG_OBSERVER_NAME, aflpp_cmp_map_dup, true);
    |                 -------------------------                             ^^^^^^^^^^^^^^^^^ expected `OwnedRefMut<'_, _>`, found `&mut AFLppCmpLogMap`
    |                 |
    |                 arguments to this function are incorrect
    |
    = note:           expected enum `OwnedRefMut<'_, _>`
            found mutable reference `&mut AFLppCmpLogMap`
note: associated function defined here
   --> /home/drt/.cargo/git/checkouts/libafl-c33dc6f5ec2f7a70/d143cac/libafl/src/observers/cmp.rs:336:12
    |
336 |     pub fn new(name: &'static str, map: OwnedRefMut<'a, CM>, add_meta: bool) -> Self {
    |            ^^^
help: try wrapping the expression in `libafl_bolts::ownedref::OwnedRefMut::Ref`
    |
169 |                 StdCmpValuesObserver::new(Self::CMPLOG_OBSERVER_NAME, libafl_bolts::ownedref::OwnedRefMut::Ref(aflpp_cmp_map_dup), true);
    |                                                                       +++++++++++++++++++++++++++++++++++++++++                 +

For more information about this error, try `rustc --explain E0308`. error: could not compile `tsffs` (lib) due to 2 previous errors /home/drt/workspace/simics/tsffs/modules/tsffs/Makefile:21: /home/drt/workspace/simics/tsffs/linux64/lib/../obj/release/libtsffs.d: No such file or directory make[1]: *** [/home/drt/workspace/simics/tsffs/modules/tsffs/Makefile:18: /home/drt/workspace/simics/tsffs/linux64/lib/../obj/release/libtsffs.d] Error 101 make: *** [/home/drt/workspace/simics/simics-6.0.169/config/project/toplevel-rules.mk:163: tsffs] Error 2 )

warning: `package.edition` is unspecified, defaulting to `2021`
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `/home/drt/.cargo/target/61/dee3841611cf01/debug/build-`
Error: Command failed with status (exit status: 2), stdout (=== Building module tsffs === CARGO /home/drt/workspace/simics/tsffs/linux64/lib/../obj/release/libtsffs.d
), stderr (   Compiling tsffs v0.2.1 (/home/drt/workspace/simics/tsffs/modules/tsffs/src/tsffs)
error[E0308]: mismatched types
   --> modules/tsffs/src/tsffs/src/fuzzer/mod.rs:169:71
    |
169 |                 StdCmpValuesObserver::new(Self::CMPLOG_OBSERVER_NAME, aflpp_cmp_map_dup, true);
    |                 -------------------------                             ^^^^^^^^^^^^^^^^^ expected `OwnedRefMut<'_, _>`, found `&mut AFLppCmpLogMap`
    |                 |
    |                 arguments to this function are incorrect
    |
    = note:           expected enum `OwnedRefMut<'_, _>`
            found mutable reference `&mut AFLppCmpLogMap`
note: associated function defined here
   --> /home/drt/.cargo/git/checkouts/libafl-c33dc6f5ec2f7a70/d143cac/libafl/src/observers/cmp.rs:336:12
    |
336 |     pub fn new(name: &'static str, map: OwnedRefMut<'a, CM>, add_meta: bool) -> Self {
    |            ^^^
help: try wrapping the expression in `libafl_bolts::ownedref::OwnedRefMut::Ref`
    |
169 |                 StdCmpValuesObserver::new(Self::CMPLOG_OBSERVER_NAME, libafl_bolts::ownedref::OwnedRefMut::Ref(aflpp_cmp_map_dup), true);
    |                                                                       +++++++++++++++++++++++++++++++++++++++++                 +

For more information about this error, try `rustc --explain E0308`. error: could not compile `tsffs` (lib) due to 1 previous error /home/drt/workspace/simics/tsffs/modules/tsffs/Makefile:21: /home/drt/workspace/simics/tsffs/linux64/lib/../obj/release/libtsffs.d: No such file or directory make[1]: *** [/home/drt/workspace/simics/tsffs/modules/tsffs/Makefile:18: /home/drt/workspace/simics/tsffs/linux64/lib/../obj/release/libtsffs.d] Error 101 make: *** [/home/drt/workspace/simics/simics-6.0.169/config/project/toplevel-rules.mk:163: tsffs] Error 2 )