### PR TITLE
Add option to output execution traces during fuzzing

### DIFF
--- a/src/arch/risc_v.rs
+++ b/src/arch/risc_v.rs
@@ -459,6 +459,16 @@ impl TracerDisassembler for Disassembler {
         Ok(())
     }
 
+    fn disassemble_to_string(&mut self, bytes: &[u8]) -> Result<String> {
+        let mut r = U8Reader::new(bytes);
+
+        if let Ok(insn) = self.decoder.decode(&mut r) {
+            Ok(insn.to_string())
+        } else {
+            bail!("Could not disassemble {:?}", bytes);
+        }
+    }
+
     fn last_was_control_flow(&self) -> bool {
         if let Some(last) = self.last.as_ref() {
             if matches!(last.opcode(), |Opcode::BEQ| Opcode::BNE

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -981,6 +981,14 @@ impl TracerDisassembler for Disassembler {
         Ok(())
     }
 
+    fn disassemble_to_string(&mut self, bytes: &[u8]) -> Result<String> {
+        if let Ok(insn) = self.decoder.decode_slice(bytes) {
+            Ok(insn.to_string())
+        } else {
+            bail!("Could not disassemble {:?}", bytes);
+        }
+    }
+
     fn cmp(&self) -> Vec<CmpExpr> {
         let mut cmp_exprs = Vec::new();
         if self.last_was_cmp() {

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -960,6 +960,14 @@ impl TracerDisassembler for Disassembler {
         Ok(())
     }
 
+    fn disassemble_to_string(&mut self, bytes: &[u8]) -> Result<String> {
+        if let Ok(insn) = self.decoder.decode_slice(bytes) {
+            Ok(insn.to_string())
+        } else {
+            bail!("Could not disassemble {:?}", bytes);
+        }
+    }
+
     fn cmp(&self) -> Vec<CmpExpr> {
         let mut cmp_exprs = Vec::new();
         if self.last_was_cmp() {

--- a/src/haps/mod.rs
+++ b/src/haps/mod.rs
@@ -58,6 +58,7 @@ impl Tsffs {
             self.post_timeout_event()?;
         }
 
+        self.execution_trace.0.clear();
         self.save_repro_bookmark_if_needed()?;
 
         debug!(self.as_conf_object(), "Resuming simulation");
@@ -152,6 +153,10 @@ impl Tsffs {
             self.post_timeout_event()?;
         }
 
+        if self.save_all_execution_traces {
+            self.save_execution_trace()?;
+        }
+
         debug!(self.as_conf_object(), "Resuming simulation");
 
         run_alone(|| {
@@ -204,6 +209,7 @@ impl Tsffs {
             self.post_timeout_event()?;
         }
 
+        self.execution_trace.0.clear();
         self.save_repro_bookmark_if_needed()?;
 
         debug!(self.as_conf_object(), "Resuming simulation");
@@ -233,6 +239,7 @@ impl Tsffs {
             self.post_timeout_event()?;
         }
 
+        self.execution_trace.0.clear();
         self.save_repro_bookmark_if_needed()?;
 
         debug!(self.as_conf_object(), "Resuming simulation");
@@ -321,6 +328,10 @@ impl Tsffs {
             }
 
             self.post_timeout_event()?;
+        }
+
+        if self.save_all_execution_traces {
+            self.save_execution_trace()?;
         }
 
         debug!(self.as_conf_object(), "Resuming simulation");
@@ -414,6 +425,10 @@ impl Tsffs {
             }
 
             self.post_timeout_event()?;
+        }
+
+        if self.save_all_execution_traces || self.save_solution_execution_traces {
+            self.save_execution_trace()?;
         }
 
         debug!(self.as_conf_object(), "Resuming simulation");

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -74,6 +74,10 @@ impl Tsffs {
 
                         self.edges_seen_since_last.clear();
                     }
+
+                    if self.save_interesting_execution_traces {
+                        self.save_execution_trace()?;
+                    }
                 }
             }
 

--- a/src/tracer/mod.rs
+++ b/src/tracer/mod.rs
@@ -6,6 +6,7 @@ use ffi::ffi;
 use libafl::prelude::CmpValues;
 use libafl_bolts::{AsMutSlice, AsSlice};
 use libafl_targets::{AFLppCmpLogOperands, AFL_CMP_TYPE_INS, CMPLOG_MAP_H};
+use serde::{Deserialize, Serialize};
 use simics::{
     api::{
         get_processor_number, sys::instruction_handle_t, AsConfObject, AttrValue, AttrValueType,
@@ -13,10 +14,36 @@ use simics::{
     },
     trace,
 };
-use std::{collections::HashMap, ffi::c_void, fmt::Display, num::Wrapping, str::FromStr};
+use std::{
+    collections::HashMap, ffi::c_void, fmt::Display, hash::Hash, num::Wrapping,
+    slice::from_raw_parts, str::FromStr,
+};
 use typed_builder::TypedBuilder;
 
 use crate::{arch::ArchitectureOperations, Tsffs};
+
+#[derive(Deserialize, Serialize, Debug, Default)]
+pub(crate) struct ExecutionTrace(pub HashMap<i32, Vec<ExecutionTraceEntry>>);
+
+impl Hash for ExecutionTrace {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for (k, v) in self.0.iter() {
+            for entry in v.iter() {
+                k.hash(state);
+                entry.hash(state);
+            }
+        }
+    }
+}
+
+#[derive(TypedBuilder, Deserialize, Serialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ExecutionTraceEntry {
+    pc: u64,
+    #[builder(default, setter(into, strip_option))]
+    insn: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    insn_bytes: Option<Vec<u8>>,
+}
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum CmpExpr {
@@ -333,6 +360,39 @@ impl Tsffs {
                         // trace!(self.as_conf_object(), "Error tracing for CMP: {e}");
                     }
                 }
+            }
+        }
+
+        if self.coverage_enabled
+            && (self.save_all_execution_traces
+                || self.save_interesting_execution_traces
+                || self.save_solution_execution_traces)
+        {
+            if let Some(arch) = self.processors.get_mut(&processor_number) {
+                self.execution_trace
+                    .0
+                    .entry(processor_number)
+                    .or_default()
+                    .push(if self.execution_trace_pc_only {
+                        ExecutionTraceEntry::builder()
+                            .pc(arch.processor_info_v2().get_program_counter()?)
+                            .build()
+                    } else {
+                        let instruction_bytes =
+                            arch.cpu_instruction_query().get_instruction_bytes(handle)?;
+                        let instruction_bytes = unsafe {
+                            from_raw_parts(instruction_bytes.data, instruction_bytes.size)
+                        };
+
+                        ExecutionTraceEntry::builder()
+                            .pc(arch.processor_info_v2().get_program_counter()?)
+                            .insn(
+                                arch.disassembler()
+                                    .disassemble_to_string(instruction_bytes)?,
+                            )
+                            .insn_bytes(instruction_bytes.to_vec())
+                            .build()
+                    });
             }
         }
 

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 /// and compare tracing
 pub trait TracerDisassembler {
     fn disassemble(&mut self, bytes: &[u8]) -> Result<()>;
+    fn disassemble_to_string(&mut self, bytes: &[u8]) -> Result<String>;
     fn last_was_control_flow(&self) -> bool;
     fn last_was_call(&self) -> bool;
     fn last_was_ret(&self) -> bool;


### PR DESCRIPTION
This adds options:

```
tsffs.save_interesting_execution_traces: bool
tsffs.save_all_execution_traces: bool
tsffs.save_solution_execution_traces: bool
tsffs.execution_trace_directory: Path
```

Which enables saving execution traces for various types of executions to be reviewed at a later time. Care should be taken when enabling these options, and it should typically be used for debug/testing, because enabling *any* execution trace saving enables *recording* of traces for *all* executions (because we do not know which are interesting until the end, and so forth). Thus enabling any trace saving has a very large performance penalty.