### PR TITLE
Disable VMP on Fuzz Start

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ version = "0.2.1"
 
 [package.metadata.simics]
 package-number = 31337
-version = "6.1.1"
+version = "6.1.2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ version = "0.2.1"
 
 [package.metadata.simics]
 package-number = 31337
-
 version = "6.1.2"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ version = "0.2.1"
 [package.metadata.simics]
 package-number = 31337
 
-version = "6.1.0"
+version = "6.1.2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ version = "0.2.1"
 
 [package.metadata.simics]
 package-number = 31337
-version = "6.1.2"
+version = "6.1.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/simics-rs/cargo-simics-build/Cargo.toml
+++ b/simics-rs/cargo-simics-build/Cargo.toml
@@ -30,6 +30,6 @@ clap = { version = "4.5.1", features = ["derive"] }
 cargo-subcommand = { version = "0.12.0", features = ["clap"] }
 command-ext = "0.1.2"
 simics-package = { version = "0.1.0", path = "../simics-package" }
-itertools = "0.12.1"
+itertools = "0.13.0"
 ispm-wrapper = { version = "0.1.0", path = "../ispm-wrapper" }
 thiserror = "1.0.57"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,10 @@ use serde_json::to_writer;
 use simics::{
     break_simulation, class, debug, error, free_attribute, get_class, get_interface,
     get_processor_number, info, lookup_file, object_clock, run_command, run_python, simics_init,
-    trace, version_base, AsConfObject, BreakpointId, ClassCreate, ClassObjectsFinalize, ConfObject,
-    CoreBreakpointMemopHap, CoreExceptionHap, CoreMagicInstructionHap, CoreSimulationStoppedHap,
-    CpuInstrumentationSubscribeInterface, Event, EventClassFlag, FromConfObject, HapHandle,
-    Interface, IntoAttrValueDict,
+    trace, version_base, warn, AsConfObject, BreakpointId, ClassCreate, ClassObjectsFinalize,
+    ConfObject, CoreBreakpointMemopHap, CoreExceptionHap, CoreMagicInstructionHap,
+    CoreSimulationStoppedHap, CpuInstrumentationSubscribeInterface, Event, EventClassFlag,
+    FromConfObject, HapHandle, Interface, IntoAttrValueDict,
 };
 #[cfg(simics_version_6)]
 use simics::{
@@ -703,6 +703,13 @@ impl Tsffs {
     pub fn save_initial_snapshot(&mut self) -> Result<()> {
         if self.have_initial_snapshot() {
             return Ok(());
+        }
+
+        // Disable VMP if it is enabled
+        info!("Disabling VMP");
+
+        if let Err(e) = run_command("disable-vmp") {
+            warn!(self.as_conf_object(), "Failed to disable VMP: {}", e);
         }
 
         #[cfg(simics_version_7)]


### PR DESCRIPTION
Disables VMP on fuzzing start with the `disable-vmp` command. This allows enabling VMP on project run start without worrying about disabling it manually later.