### PR TITLE
cargo: patch darling to avoid getters2 breakage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,8 +116,22 @@ versions = { version = "6.2.0", features = ["serde"] }
 simics = "0.1.2"
 simics-build-utils = "0.1.1"
 
+
 [profile.release]
 lto = true
 codegen-units = 1
 opt-level = 3
 debug = true
+
+# Temporary patch to pin darling to v0.20.10
+[patch.crates-io]
+ffi = { git = "https://github.com/Wenzel/ffi", rev = "496832d73717bb8e1ec82ea6603bbf393f451167" }
+cargo-simics-build = { git = "https://github.com/Wenzel/simulator-bindings.git", rev = "174943b23558f9365690d75212baa84d3b84e036" }
+ispm-wrapper = { git = "https://github.com/Wenzel/simulator-bindings.git", rev = "174943b23558f9365690d75212baa84d3b84e036" }
+simics = { git = "https://github.com/Wenzel/simulator-bindings.git", rev = "174943b23558f9365690d75212baa84d3b84e036" }
+simics-api-sys = { git = "https://github.com/Wenzel/simulator-bindings.git", rev = "174943b23558f9365690d75212baa84d3b84e036" }
+simics-macro = { git = "https://github.com/Wenzel/simulator-bindings.git", rev = "174943b23558f9365690d75212baa84d3b84e036" }
+simics-package = { git = "https://github.com/Wenzel/simulator-bindings.git", rev = "174943b23558f9365690d75212baa84d3b84e036" }
+simics-sign = { git = "https://github.com/Wenzel/simulator-bindings.git", rev = "174943b23558f9365690d75212baa84d3b84e036" }
+simics-test = { git = "https://github.com/Wenzel/simulator-bindings.git", rev = "174943b23558f9365690d75212baa84d3b84e036" }
+simics-build-utils = { git = "https://github.com/Wenzel/simulator-bindings.git", rev = "174943b23558f9365690d75212baa84d3b84e036" }


### PR DESCRIPTION
```rust
    Compiling simics-sign v0.1.1
   Compiling libafl_targets v0.11.2 (https://github.com/AFLplusplus/LibAFL?rev=0f26f6ea32aa74ee526636558842ec06bbfb49bb#0f26f6ea)
   Compiling cargo-simics-build v0.1.1
   Compiling getters2 v0.1.4
error: field will not be populated because `forward_attrs` is not set on the struct
   --> /github/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getters2-0.1.4/src/lib.rs:293:5
    |
293 |     attrs: Vec<Attribute>,
    |     ^^^^^
error: field will not be populated because `forward_attrs` is not set on the struct
   --> /github/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getters2-0.1.4/src/lib.rs:310:5
    |
310 |     attrs: Vec<Attribute>,
    |     ^^^^^
error[E0277]: the trait bound `GettersVariant: FromVariant` is not satisfied
   --> /github/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getters2-0.1.4/src/lib.rs:354:5
    |
354 |     data: Data<GettersVariant, GettersField>,
    |     ^^^^ the trait `FromVariant` is not implemented for `GettersVariant`
    |
    = help: the following other types implement trait `FromVariant`:
              ()
              Ignored
              SpannedValue<T>
              Variant
              Vec<Attribute>
              WithOriginal<T, Variant>
              proc_macro2::Ident
note: required by a bound in `darling::ast::Data::<V, F>::try_from`
   --> /github/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/darling_core-0.20.11/src/ast/data.rs:122:9
    |
122 | impl<V: FromVariant, F: FromField> Data<V, F> {
    |         ^^^^^^^^^^^ required by this bound in `Data::<V, F>::try_from`
123 |     /// Attempt to convert from a `syn::Data` instance.
124 |     pub fn try_from(body: &syn::Data) -> Result<Self> {
    |            -------- required by a bound in this associated function
error[E0277]: the trait bound `GettersField: FromField` is not satisfied
   --> /github/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getters2-0.1.4/src/lib.rs:354:5
    |
354 |     data: Data<GettersVariant, GettersField>,
    |     ^^^^ the trait `FromField` is not implemented for `GettersField`
    |
    = help: the following other types implement trait `FromField`:
              ()
              Ignored
              SpannedValue<T>
              Vec<Attribute>
              Visibility
              WithOriginal<T, syn::Field>
              darling_core::options::forwarded_field::ForwardedField
              syn::Field
              syn::Type
note: required by a bound in `darling::ast::Data::<V, F>::try_from`
   --> /github/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/darling_core-0.20.11/src/ast/data.rs:122:25
    |
122 | impl<V: FromVariant, F: FromField> Data<V, F> {
    |                         ^^^^^^^^^ required by this bound in `Data::<V, F>::try_from`
123 |     /// Attempt to convert from a `syn::Data` instance.
124 |     pub fn try_from(body: &syn::Data) -> Result<Self> {
    |            -------- required by a bound in this associated function
For more information about this error, try `rustc --explain E0277`.
error: could not compile `getters2` (lib) due to 4 previous errors
warning: build failed, waiting for other jobs to finish...
❗ Tests failed
Error: Process completed with exit code 1.
```