### PR TITLE
Dockerfile: add missing awk dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN dnf -y update && \
     dnf -y install \
     alsa-lib \
     atk \
+    awk \
     bash \
     clang \
     clang-libs \


### PR DESCRIPTION
Spotted on [dockerfile_dev ](https://github.com/intel/tsffs/tree/dockerfile_dev) branch, after Fedora 41 baseimage update

~~~shell
[2025-07-09T14:48:18.595Z] Stop (269 ms): Run in container: test -x '/home/docker4/.vscode-server/bin/2901c5ac6db8a986a5666c3af51ff804d05af0d4/bin/helpers/check-requirements.sh'
[2025-07-09T14:48:18.595Z] Start: Run in container: '/home/docker4/.vscode-server/bin/2901c5ac6db8a986a5666c3af51ff804d05af0d4/bin/helpers/check-requirements.sh'
[2025-07-09T14:48:18.935Z] Start: Run in container: touch '/vscode/vscode-server/bin/linux-x64/2901c5ac6db8a986a5666c3af51ff804d05af0d4'
[2025-07-09T14:48:18.937Z] 
[2025-07-09T14:48:18.937Z] /home/docker4/.vscode-server/bin/2901c5ac6db8a986a5666c3af51ff804d05af0d4/bin/helpers/check-requirements.sh: line 66: awk: command not found
[2025-07-09T14:48:18.937Z] Exit code 127
[2025-07-09T14:48:18.938Z] Stop (343 ms): Run in container: '/home/docker4/.vscode-server/bin/2901c5ac6db8a986a5666c3af51ff804d05af0d4/bin/helpers/check-requirements.sh'
[2025-07-09T14:48:18.948Z] Command in container failed: '/home/docker4/.vscode-server/bin/2901c5ac6db8a986a5666c3af51ff804d05af0d4/bin/helpers/check-requirements.sh'
[2025-07-09T14:48:18.948Z] /home/docker4/.vscode-server/bin/2901c5ac6db8a986a5666c3af51ff804d05af0d4/bin/helpers/check-requirements.sh: line 66: awk: command not found
[2025-07-09T14:48:18.949Z] Exit code 127
~~~