### PR TITLE
Fix register destinations for aarch64 harness to match arch/aarch64.rs and add clobber lists for ARM and aarch64

### DIFF
--- a/harness/tsffs-gcc-aarch64.h
+++ b/harness/tsffs-gcc-aarch64.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Definitions and macros for compiled-in harnessing of C and C++ target
-/// software for the RISC-V (32-bit) architecture
+/// software for the aarch64 architecture
 
 #ifndef TSFFS_H
 #define TSFFS_H
@@ -40,10 +40,11 @@
 /// * `arg0` - The value to place in register `r10`
 #define __orr_extended1(value, arg0)                           \
   __asm__ __volatile__(                                        \
-      "mov x28, %0; orr x" __tostring(value) ", x" __tostring( \
+      "mov x10, %0; orr x" __tostring(value) ", x" __tostring( \
           value) ", x" __tostring(value)                       \
       :                                                        \
-      : "g"(arg0));
+      : "g"((unsigned long long)arg0)                          \
+      : "x10");
 
 /// __orr_extended2
 ///
@@ -58,10 +59,11 @@
 /// * `arg1` - The value to place in register `r9`
 #define __orr_extended2(value, arg0, arg1)                                  \
   __asm__ __volatile__(                                                     \
-      "mov x28, %0; mov x27, %1; orr x" __tostring(value) ", x" __tostring( \
+      "mov x10, %0; mov x9, %1; orr x" __tostring(value) ", x" __tostring(  \
           value) ", x" __tostring(value)                                    \
       :                                                                     \
-      : "r"(arg0), "r"(arg1));
+      : "r"((unsigned long long)arg0), "r"((unsigned long long)arg1)        \
+      : "x10", "x9");
 
 /// __orr_extended3
 ///
@@ -75,12 +77,14 @@
 /// * `arg0` - The value to place in register `r10`
 /// * `arg1` - The value to place in register `r9`
 /// * `arg2` - The value to place in register `r8`
-#define __orr_extended3(value, arg0, arg1, arg2)                 \
-  __asm__ __volatile__(                                          \
-      "mov x28, %0; mov x27, %1; mov x26, %2; orr x" __tostring( \
-          value) ", x" __tostring(value) ", x" __tostring(value) \
-      :                                                          \
-      : "r"(arg0), "r"(arg1), "r"(arg2));
+#define __orr_extended3(value, arg0, arg1, arg2)                      \
+  __asm__ __volatile__(                                               \
+      "mov x10, %0; mov x9, %1; mov x8, %2; orr x" __tostring(        \
+          value) ", x" __tostring(value) ", x" __tostring(value)      \
+      :                                                               \
+      : "r"((unsigned long long)arg0), "r"((unsigned long long)arg1), \
+        "r"((unsigned long long)arg2)                                 \
+      : "x10", "x9");
 
 /// __orr_extended4
 ///
@@ -97,16 +101,18 @@
 /// * `arg3` - The value to place in register `r7`
 #define __orr_extended4(value, arg0, arg1, arg2, arg3)                    \
   __asm__ __volatile__(                                                   \
-      "mov x28, %0; mov x27, %1; mov x26, %2; mov x25, %3; "              \
+      "mov x10, %0; mov x9, %1; mov x8, %2; mov x7, %3; "                 \
       "orr x" __tostring(value) ", x" __tostring(value) ", x" __tostring( \
           value)                                                          \
       :                                                                   \
-      : "r"(arg0), "r"(arg1), "r"(arg2), "r"(arg3));
+      : "r"((unsigned long long)arg0), "r"((unsigned long long)arg1),     \
+        "r"((unsigned long long)arg2), "r"((unsigned long long)arg3)      \
+      : "x10", "x9");
 
 /// The default index number used for magic instructions. All magic instructions
 /// support multiple start and stop indices, which defaults to 0 if not
 /// specified.
-#define DEFAULT_INDEX (0x0000U)
+#define DEFAULT_INDEX (0x0000)
 
 /// Pseudo-hypercall number to signal the fuzzer to use the first argument to
 /// the magic instruction as the pointer to the testcase buffer and the second
@@ -178,7 +184,7 @@
 /// ```
 /// unsigned char buffer[1024];
 /// size_t size;
-/// HARNESS_START_INDEX(0x0001U, buffer, &size);
+/// HARNESS_START_INDEX(0x0001, buffer, &size);
 /// ```
 #define HARNESS_START_INDEX(start_index, buffer, size_ptr)            \
   do {                                                                \
@@ -254,7 +260,7 @@
 ///
 /// ```
 /// unsigned char buffer[1024];
-/// HARNESS_START_WITH_MAXIMUM_SIZE_INDEX(0x0001U, buffer, 1024);
+/// HARNESS_START_WITH_MAXIMUM_SIZE_INDEX(0x0001, buffer, 1024);
 /// ```
 #define HARNESS_START_WITH_MAXIMUM_SIZE_INDEX(start_index, buffer, max_size) \
   do {                                                                       \
@@ -388,7 +394,7 @@
 /// # Example
 ///
 /// ```
-/// HARNESS_STOP_INDEX(0x0001U);
+/// HARNESS_STOP_INDEX(0x0001);
 /// ```
 #define HARNESS_STOP_INDEX(stop_index)          \
   do {                                          \
@@ -437,7 +443,7 @@
 /// # Example
 ///
 /// ```
-/// HARNESS_ASSERT_INDEX(0x0001U);
+/// HARNESS_ASSERT_INDEX(0x0001);
 /// ```
 #define HARNESS_ASSERT_INDEX(assert_index)        \
   do {                                            \

--- a/harness/tsffs-gcc-arm32.h
+++ b/harness/tsffs-gcc-arm32.h
@@ -43,7 +43,8 @@
       "mov r10, %0; orr r" __tostring(value) ", r" __tostring( \
           value) ", r" __tostring(value)                       \
       :                                                        \
-      : "r"(arg0));
+      : "r"(arg0)                                              \
+      : "r10");
 
 /// __orr_extended2
 ///
@@ -61,7 +62,8 @@
       "mov r10, %0; mov r9, %1; orr r" __tostring(value) ", r" __tostring( \
           value) ", r" __tostring(value)                                   \
       :                                                                    \
-      : "r"(arg0), "r"(arg1));
+      : "r"(arg0), "r"(arg1)                                               \
+      : "r10", "r9");
 
 /// __orr_extended3
 ///
@@ -80,7 +82,8 @@
       "mov r10, %0; mov r9, %1; mov r8, %2; orr r" __tostring(   \
           value) ", r" __tostring(value) ", r" __tostring(value) \
       :                                                          \
-      : "r"(arg0), "r"(arg1), "r"(arg2));
+      : "r"(arg0), "r"(arg1), "r"(arg2)                          \
+      : "r10", "r9", "r8");
 
 /// __orr_extended4
 ///
@@ -101,7 +104,8 @@
       "orr r" __tostring(value) ", r" __tostring(value) ", r" __tostring( \
           value)                                                          \
       :                                                                   \
-      : "r"(arg0), "r"(arg1), "r"(arg2), "r"(arg3));
+      : "r"(arg0), "r"(arg1), "r"(arg2), "r"(arg3)                        \
+      : "r10", "r9", "r8", "r7");
 
 /// Magic value defined by SIMICS as the "leaf" value of a CPUID instruction
 /// that is treated as a magic instruction.

--- a/harness/tsffs.h
+++ b/harness/tsffs.h
@@ -1845,7 +1845,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Definitions and macros for compiled-in harnessing of C and C++ target
-/// software for the RISC-V (32-bit) architecture
+/// software for the aarch64 architecture
 
 #ifndef TSFFS_H
 #define TSFFS_H
@@ -1883,10 +1883,11 @@
 /// * `arg0` - The value to place in register `r10`
 #define __orr_extended1(value, arg0)                           \
   __asm__ __volatile__(                                        \
-      "mov x28, %0; orr x" __tostring(value) ", x" __tostring( \
+      "mov x10, %0; orr x" __tostring(value) ", x" __tostring( \
           value) ", x" __tostring(value)                       \
       :                                                        \
-      : "g"(arg0));
+      : "g"((unsigned long long)arg0)                          \
+      : "x10");
 
 /// __orr_extended2
 ///
@@ -1901,10 +1902,11 @@
 /// * `arg1` - The value to place in register `r9`
 #define __orr_extended2(value, arg0, arg1)                                  \
   __asm__ __volatile__(                                                     \
-      "mov x28, %0; mov x27, %1; orr x" __tostring(value) ", x" __tostring( \
+      "mov x10, %0; mov x9, %1; orr x" __tostring(value) ", x" __tostring(  \
           value) ", x" __tostring(value)                                    \
       :                                                                     \
-      : "r"(arg0), "r"(arg1));
+      : "r"((unsigned long long)arg0), "r"((unsigned long long)arg1)        \
+      : "x10", "x9");
 
 /// __orr_extended3
 ///
@@ -1918,12 +1920,14 @@
 /// * `arg0` - The value to place in register `r10`
 /// * `arg1` - The value to place in register `r9`
 /// * `arg2` - The value to place in register `r8`
-#define __orr_extended3(value, arg0, arg1, arg2)                 \
-  __asm__ __volatile__(                                          \
-      "mov x28, %0; mov x27, %1; mov x26, %2; orr x" __tostring( \
-          value) ", x" __tostring(value) ", x" __tostring(value) \
-      :                                                          \
-      : "r"(arg0), "r"(arg1), "r"(arg2));
+#define __orr_extended3(value, arg0, arg1, arg2)                      \
+  __asm__ __volatile__(                                               \
+      "mov x10, %0; mov x9, %1; mov x8, %2; orr x" __tostring(        \
+          value) ", x" __tostring(value) ", x" __tostring(value)      \
+      :                                                               \
+      : "r"((unsigned long long)arg0), "r"((unsigned long long)arg1), \
+        "r"((unsigned long long)arg2)                                 \
+      : "x10", "x9");
 
 /// __orr_extended4
 ///
@@ -1940,16 +1944,18 @@
 /// * `arg3` - The value to place in register `r7`
 #define __orr_extended4(value, arg0, arg1, arg2, arg3)                    \
   __asm__ __volatile__(                                                   \
-      "mov x28, %0; mov x27, %1; mov x26, %2; mov x25, %3; "              \
+      "mov x10, %0; mov x9, %1; mov x8, %2; mov x7, %3; "                 \
       "orr x" __tostring(value) ", x" __tostring(value) ", x" __tostring( \
           value)                                                          \
       :                                                                   \
-      : "r"(arg0), "r"(arg1), "r"(arg2), "r"(arg3));
+      : "r"((unsigned long long)arg0), "r"((unsigned long long)arg1),     \
+        "r"((unsigned long long)arg2), "r"((unsigned long long)arg3)      \
+      : "x10", "x9");
 
 /// The default index number used for magic instructions. All magic instructions
 /// support multiple start and stop indices, which defaults to 0 if not
 /// specified.
-#define DEFAULT_INDEX (0x0000U)
+#define DEFAULT_INDEX (0x0000)
 
 /// Pseudo-hypercall number to signal the fuzzer to use the first argument to
 /// the magic instruction as the pointer to the testcase buffer and the second
@@ -2021,7 +2027,7 @@
 /// ```
 /// unsigned char buffer[1024];
 /// size_t size;
-/// HARNESS_START_INDEX(0x0001U, buffer, &size);
+/// HARNESS_START_INDEX(0x0001, buffer, &size);
 /// ```
 #define HARNESS_START_INDEX(start_index, buffer, size_ptr)            \
   do {                                                                \
@@ -2097,7 +2103,7 @@
 ///
 /// ```
 /// unsigned char buffer[1024];
-/// HARNESS_START_WITH_MAXIMUM_SIZE_INDEX(0x0001U, buffer, 1024);
+/// HARNESS_START_WITH_MAXIMUM_SIZE_INDEX(0x0001, buffer, 1024);
 /// ```
 #define HARNESS_START_WITH_MAXIMUM_SIZE_INDEX(start_index, buffer, max_size) \
   do {                                                                       \
@@ -2231,7 +2237,7 @@
 /// # Example
 ///
 /// ```
-/// HARNESS_STOP_INDEX(0x0001U);
+/// HARNESS_STOP_INDEX(0x0001);
 /// ```
 #define HARNESS_STOP_INDEX(stop_index)          \
   do {                                          \
@@ -2280,7 +2286,7 @@
 /// # Example
 ///
 /// ```
-/// HARNESS_ASSERT_INDEX(0x0001U);
+/// HARNESS_ASSERT_INDEX(0x0001);
 /// ```
 #define HARNESS_ASSERT_INDEX(assert_index)        \
   do {                                            \
@@ -2334,7 +2340,8 @@
       "mov r10, %0; orr r" __tostring(value) ", r" __tostring( \
           value) ", r" __tostring(value)                       \
       :                                                        \
-      : "r"(arg0));
+      : "r"(arg0)                                              \
+      : "r10");
 
 /// __orr_extended2
 ///
@@ -2352,7 +2359,8 @@
       "mov r10, %0; mov r9, %1; orr r" __tostring(value) ", r" __tostring( \
           value) ", r" __tostring(value)                                   \
       :                                                                    \
-      : "r"(arg0), "r"(arg1));
+      : "r"(arg0), "r"(arg1)                                               \
+      : "r10", "r9");
 
 /// __orr_extended3
 ///
@@ -2371,7 +2379,8 @@
       "mov r10, %0; mov r9, %1; mov r8, %2; orr r" __tostring(   \
           value) ", r" __tostring(value) ", r" __tostring(value) \
       :                                                          \
-      : "r"(arg0), "r"(arg1), "r"(arg2));
+      : "r"(arg0), "r"(arg1), "r"(arg2)                          \
+      : "r10", "r9", "r8");
 
 /// __orr_extended4
 ///
@@ -2392,7 +2401,8 @@
       "orr r" __tostring(value) ", r" __tostring(value) ", r" __tostring( \
           value)                                                          \
       :                                                                   \
-      : "r"(arg0), "r"(arg1), "r"(arg2), "r"(arg3));
+      : "r"(arg0), "r"(arg1), "r"(arg2), "r"(arg3)                        \
+      : "r10", "r9", "r8", "r7");
 
 /// Magic value defined by SIMICS as the "leaf" value of a CPUID instruction
 /// that is treated as a magic instruction.


### PR DESCRIPTION
This PR fixes an issue reported via Discord where registers were not set correctly on aarch64 to correspond with the code that extracts them from harness macro invocations.
