### PR TITLE
fix(simics7): replace set-bookmark with snapshot for repro mode

### DIFF
--- a/docs/src/fuzzing/analyzing-results.md
+++ b/docs/src/fuzzing/analyzing-results.md
@@ -2,7 +2,8 @@
 
 Once a solution is found, the fuzzer can be run in *repro* mode which will:
 
-* Save a bookmark when the testcase is written
+* Mark a restore point at the moment the testcase is written (a bookmark on SIMICS 6,
+  the initial snapshot on SIMICS 7)
 * Write only one testcase, the bytes from the specified file
 * Stop without resetting to the initial snapshot
 

--- a/docs/src/tutorials/edk2-uefi/reproducing-runs.md
+++ b/docs/src/tutorials/edk2-uefi/reproducing-runs.md
@@ -110,7 +110,7 @@ Or add it at the end of your script directly, after the `run` line:
 new-gdb-remote
 ```
 
-SIMICS output:
+SIMICS output (Simics 7; Simics 6 shows `reverse-to start` instead):
 
 ```txt
 [tsffs info] Stopped for repro. Restore origin state with 'restore-snapshot tsffs-origin-snapshot'

--- a/docs/src/tutorials/edk2-uefi/reproducing-runs.md
+++ b/docs/src/tutorials/edk2-uefi/reproducing-runs.md
@@ -40,12 +40,25 @@ simics> @tsffs.iface.fuzz.repro("%simics%/corpus/4385dc33f608888d")
 
 ## Inspecting State with SIMICS Reverse Debugging
 
-By default, the simulation runs the testcase through to completion and saves a bookmark
-at the point the harness was triggered. You can then replay the execution by running:
+By default, the simulation runs the testcase through to completion and preserves the
+state at the point the harness was triggered. How you replay it depends on which SIMICS
+version you are running:
 
-```txt
-simics> reverse-to start
-```
+- On **SIMICS 6**, TSFFS uses reverse-execution bookmarks. Restore the start state with:
+
+  ```txt
+  simics> reverse-to start
+  ```
+
+- On **SIMICS 7**, the `set-bookmark` / `reverse-to` commands have been removed. TSFFS
+  uses a snapshot named `tsffs-origin-snapshot` instead. Restore it with:
+
+  ```txt
+  simics> restore-snapshot tsffs-origin-snapshot
+  ```
+
+TSFFS prints the exact command to use in the `Stopped for repro.` log line, so you can
+just copy it from there.
 
 From here, you can examine memory and registers (with `x`), single step execution (`si`)
 and more! Check out the SIMICS documentation and explore all the deep debugging
@@ -100,7 +113,7 @@ new-gdb-remote
 SIMICS output:
 
 ```txt
-[tsffs info] Stopped for repro. Restore to start bookmark with 'reverse-to start'
+[tsffs info] Stopped for repro. Restore origin state with 'restore-snapshot tsffs-origin-snapshot'
 No CPU is specified; using current processor.
 [gdb0 info] Attached to CPU: qsp.mb.cpu0.core[0][0]
 Warning: This can expose the target system on the host local network.

--- a/src/haps/mod.rs
+++ b/src/haps/mod.rs
@@ -199,7 +199,8 @@ impl Tsffs {
 
                 info!(
                     self.as_conf_object(),
-                    "Stopped for repro. Restore to start bookmark with 'reverse-to start'"
+                    "Stopped for repro. Restore origin state with '{}'",
+                    Tsffs::REPRO_RESTORE_COMMAND
                 );
 
                 // Skip the shutdown and continue, we are finished here
@@ -359,7 +360,8 @@ impl Tsffs {
 
                 info!(
                     self.as_conf_object(),
-                    "Stopped for repro. Restore to start bookmark with 'reverse-to start'"
+                    "Stopped for repro. Restore origin state with '{}'",
+                    Tsffs::REPRO_RESTORE_COMMAND
                 );
 
                 // Skip the shutdown and continue, we are finished here
@@ -414,7 +416,8 @@ impl Tsffs {
 
                 info!(
                     self.as_conf_object(),
-                    "Stopped for repro. Restore to start bookmark with 'reverse-to start'"
+                    "Stopped for repro. Restore origin state with '{}'",
+                    Tsffs::REPRO_RESTORE_COMMAND
                 );
 
                 // Skip the shutdown and continue, we are finished here

--- a/src/haps/mod.rs
+++ b/src/haps/mod.rs
@@ -200,7 +200,7 @@ impl Tsffs {
                 info!(
                     self.as_conf_object(),
                     "Stopped for repro. Restore origin state with '{}'",
-                    Tsffs::REPRO_RESTORE_COMMAND
+                    Tsffs::repro_restore_command()
                 );
 
                 // Skip the shutdown and continue, we are finished here
@@ -361,7 +361,7 @@ impl Tsffs {
                 info!(
                     self.as_conf_object(),
                     "Stopped for repro. Restore origin state with '{}'",
-                    Tsffs::REPRO_RESTORE_COMMAND
+                    Tsffs::repro_restore_command()
                 );
 
                 // Skip the shutdown and continue, we are finished here
@@ -417,7 +417,7 @@ impl Tsffs {
                 info!(
                     self.as_conf_object(),
                     "Stopped for repro. Restore origin state with '{}'",
-                    Tsffs::REPRO_RESTORE_COMMAND
+                    Tsffs::repro_restore_command()
                 );
 
                 // Skip the shutdown and continue, we are finished here

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,14 +48,16 @@ use serde::{Deserialize, Serialize};
 use serde_json::to_writer;
 use simics::continue_simulation;
 use simics::{
-    break_simulation, class, debug, error, free_attribute, get_class, get_interface,
-    get_processor_number, info, lookup_file, object_clock, run_alone, run_command, run_python,
-    simics_init, sys::save_flags_t, trace, version_base, warn, write_configuration_to_file,
-    AsConfObject, BreakpointId, ClassCreate, ClassObjectsFinalize, ConfObject,
-    CoreBreakpointMemopHap, CoreControlRegisterWriteHap, CoreExceptionHap, CoreMagicInstructionHap,
+    break_simulation, class, debug, error, get_class, get_interface, get_processor_number, info,
+    lookup_file, object_clock, run_alone, run_command, run_python, simics_init, sys::save_flags_t,
+    trace, version_base, warn, write_configuration_to_file, AsConfObject, BreakpointId,
+    ClassCreate, ClassObjectsFinalize, ConfObject, CoreBreakpointMemopHap,
+    CoreControlRegisterWriteHap, CoreExceptionHap, CoreMagicInstructionHap,
     CoreSimulationStoppedHap, CpuInstrumentationSubscribeInterface, Event, EventClassFlag,
     FromConfObject, HapHandle, Interface,
 };
+#[cfg(simics_version = "6")]
+use simics::free_attribute;
 #[cfg(simics_version = "6")]
 use simics::{
     discard_future, restore_micro_checkpoint, save_micro_checkpoint, MicroCheckpointFlags,
@@ -664,6 +666,13 @@ impl Tsffs {
     pub const TIMEOUT_EVENT_NAME: &'static str = "detector_timeout_event";
     /// The name of the initial snapshot
     pub const SNAPSHOT_NAME: &'static str = "tsffs-origin-snapshot";
+    /// CLI command shown to the user to restore the origin state when stopped for repro.
+    /// Simics 6 used reverse-execution bookmarks; Simics 7 uses snapshots and dropped
+    /// `set-bookmark`/`reverse-to`.
+    #[cfg(simics_version = "6")]
+    pub const REPRO_RESTORE_COMMAND: &'static str = "reverse-to start";
+    #[cfg(simics_version = "7")]
+    pub const REPRO_RESTORE_COMMAND: &'static str = "restore-snapshot tsffs-origin-snapshot";
 }
 
 /// Implementations for controlling the simulation
@@ -862,6 +871,9 @@ impl Tsffs {
     /// Save a repro bookmark if one is needed
     pub fn save_repro_bookmark_if_needed(&mut self) -> Result<()> {
         if self.repro_testcase.is_some() && !self.repro_bookmark_set {
+            // On Simics 7 the reverse-execution `set-bookmark` CLI command is gone;
+            // the existing `Self::SNAPSHOT_NAME` snapshot is what gets restored for repro.
+            #[cfg(simics_version = "6")]
             free_attribute(run_command("set-bookmark start")?)?;
             self.repro_bookmark_set = true;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,13 +666,17 @@ impl Tsffs {
     pub const TIMEOUT_EVENT_NAME: &'static str = "detector_timeout_event";
     /// The name of the initial snapshot
     pub const SNAPSHOT_NAME: &'static str = "tsffs-origin-snapshot";
+}
+
+impl Tsffs {
     /// CLI command shown to the user to restore the origin state when stopped for repro.
-    /// Simics 6 used reverse-execution bookmarks; Simics 7 uses snapshots and dropped
-    /// `set-bookmark`/`reverse-to`.
-    #[cfg(simics_version = "6")]
-    pub const REPRO_RESTORE_COMMAND: &'static str = "reverse-to start";
-    #[cfg(simics_version = "7")]
-    pub const REPRO_RESTORE_COMMAND: &'static str = "restore-snapshot tsffs-origin-snapshot";
+    /// Simics 6 uses reverse-execution bookmarks; Simics 7 uses snapshots.
+    pub fn repro_restore_command() -> String {
+        #[cfg(simics_version = "6")]
+        return "reverse-to start".to_string();
+        #[cfg(simics_version = "7")]
+        return format!("restore-snapshot {}", Self::SNAPSHOT_NAME);
+    }
 }
 
 /// Implementations for controlling the simulation


### PR DESCRIPTION
## Summary

- Gates the `set-bookmark` call with `#[cfg(simics_version = "6")]` — the command was removed in Simics 7.70+
- On Simics 7, repro mode reuses the existing `tsffs-origin-snapshot` (already saved at harness start)
- Adds `REPRO_RESTORE_COMMAND` constant to display the correct restore command per version in log messages
- Updates docs to explain the version difference

## Test plan

- [ ] Verify `cargo check` passes on Simics 7 (no `set-bookmark` error)
- [ ] Verify repro mode works on Simics 6 (bookmark flow unchanged)
- [ ] Confirm log message prints correct command per Simics version

Fixes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)