### PR TITLE
docs: generate llms-full.txt for LLM accessibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,13 @@ jobs:
         run: |
           pushd docs || exit 1
           mdbook build
+          # Generate llms-full.txt: a single concatenated Markdown file of all docs
+          # in SUMMARY.md order, for LLM consumption (see https://llmstxt.org/).
+          # Extracts .md paths from SUMMARY.md links, then concatenates each file
+          # with a blank line separator. Output is served at /llms-full.txt.
+          grep -oP '\([^)]+\.md\)' src/SUMMARY.md | tr -d '()' | while read -r f; do
+            echo; cat "src/$f"
+          done > book/html/llms-full.txt
           popd || exit 1
 
       - name: Cache SIMICS Dependencies


### PR DESCRIPTION
Fixes #355

## Summary

- Adds a single shell step in the docs CI pipeline that concatenates all documentation pages (in `SUMMARY.md` order) into a single `llms-full.txt` file
- The file is served at https://intel.github.io/tsffs/llms-full.txt
- Allows LLMs to ingest the full TSFFS documentation in a single request, without crawling ~77 individual HTML pages

## Changes

Single addition to `.github/workflows/docs.yml` after `mdbook build`:

```bash
grep -oP '\([^)]+\.md\)' src/SUMMARY.md | tr -d '()' | while read -r f; do
  echo; cat "src/$f"
done > book/html/llms-full.txt
```

## Why this approach

- **No new tools or dependencies** — pure shell, runs in the existing CI environment
- **Zero ongoing maintenance** — file regenerates automatically on every doc change
- **~213 KB / ~6000 lines** — fits in a single large LLM context window
- **Correct ordering** — follows `SUMMARY.md` chapter order (intro → setup → config → harnessing → fuzzing → tutorials → developer)

## Test plan

- [x] Tested generation locally — output verified to be well-formed and complete
- [ ] CI passes (docs build + linkcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)